### PR TITLE
Add path filter to ci workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,6 +3,14 @@ name: CI
 on:
     workflow_dispatch:
     pull_request:
+      paths:
+        - '.github/workflows/ci.yaml'
+        - 'app/**'
+        - 'sql/**'
+        - 'tests/**'
+        - 'Makefile'
+        - 'poetry.lock'
+        - 'pyproject.toml'
     push:
         branches:
             - main


### PR DESCRIPTION
So that these python tests only run when we change relevant files.