### PR TITLE
Remove docker compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   app:
     build:
@@ -14,7 +12,7 @@ services:
     ports:
       - 8501:8501
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8501/health" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8501/health"]
       interval: 5s
       timeout: 10s
       retries: 5
@@ -28,13 +26,13 @@ services:
 
   app_ssl:
     image: httpd
-    restart: 'no'
+    restart: "no"
     ports:
-      - '8541:443'
+      - "8541:443"
     volumes:
-      - './secrets:/usr/local/secrets'
-      - './docker/httpd.conf:/usr/local/apache2/conf/httpd.conf'
-      - './docker/httpd-ssl.conf:/usr/local/apache2/conf/extra/httpd-ssl.conf'
+      - "./secrets:/usr/local/secrets"
+      - "./docker/httpd.conf:/usr/local/apache2/conf/httpd.conf"
+      - "./docker/httpd-ssl.conf:/usr/local/apache2/conf/extra/httpd-ssl.conf"
     depends_on:
       app:
         condition: service_healthy
@@ -58,7 +56,6 @@ networks:
   zmodules:
     driver: bridge
     name: zmodules
-
 
 volumes:
   secrets:


### PR DESCRIPTION
Previously, the `WARN[0000] /Users/bas/code/gfmodules-national-referral-index/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion` warning was given. This pull request solves that.