### PR TITLE
Disable audience verification in JWT validation

### DIFF
--- a/app/jwt_validator.py
+++ b/app/jwt_validator.py
@@ -93,6 +93,7 @@ class JwtValidator:
             "verify_exp": True,
             "verify_iat": True,
             "verify_nbf": True,
+            "verify_aud": False,
         }
 
         # Use the certificate’s public key to check the JWT signature.


### PR DESCRIPTION
We cannot verify audience so it must be deactivated for the default is true