### PR TITLE
Update CMD in Dockerfile to use docker-entrypoint.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,9 +63,9 @@ RUN if [ "$standalone" = "true" ] ; then \
 
 USER ${APP_USER}
 
-EXPOSE 8502:8502
+EXPOSE 8502
 WORKDIR ${PROJECT_DIR}
 
 ENV PYTHONPATH=${PROJECT_DIR}
 
-CMD ["docker/./init.sh", "localisation_db"]
+CMD ["/docker-entrypoint.sh"]


### PR DESCRIPTION
Use Entrypoint instead of hardcoded.

Expose only PORT -> https://docs.docker.com/reference/build-checks/expose-invalid-format/

https://github.com/minvws/gfmodules-nationale-verwijsindex-private/blob/19527caff10fa7309e650d1363c5a3df6b5142a3/docker/Dockerfile#L58-L62