### PR TITLE
feat: decoupling app from DataDomain definitions to use FhirResources

### DIFF
--- a/app/data.py
+++ b/app/data.py
@@ -1,48 +1,6 @@
 import uuid
 from dataclasses import dataclass
-from enum import Enum
-from typing import Any, Optional
-
-
-# DataDomain definitions
-class DataDomain(Enum):
-    Unknown = "unknown"
-    ImagingStudy = "beeldbank"
-    MedicationStatement = "medicatie verklaring"
-    CarePlan = "zorgplan"
-
-    @classmethod
-    def from_str(cls, label: str) -> Optional["DataDomain"]:
-        try:
-            return cls(label.lower())
-        except ValueError:
-            return None
-
-    @classmethod
-    def from_fhir(cls, label: str) -> Optional["DataDomain"]:
-        match label:
-            case "ImagingStudy":
-                return DataDomain.ImagingStudy
-            case "MedicationStatement":
-                return DataDomain.MedicationStatement
-            case "CarePlan":
-                return DataDomain.CarePlan
-            case _:
-                return None
-
-    def to_fhir(self) -> str:
-        match self:
-            case DataDomain.ImagingStudy:
-                return "ImagingStudy"
-            case DataDomain.MedicationStatement:
-                return "MedicationStatement"
-            case DataDomain.CarePlan:
-                return "CarePlan"
-            case _:
-                return ""
-
-    def __str__(self) -> str:
-        return self.value
+from typing import Any
 
 
 @dataclass

--- a/app/db/repository/referral_repository.py
+++ b/app/db/repository/referral_repository.py
@@ -3,7 +3,7 @@ from typing import List
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
-from app.data import DataDomain, Pseudonym, UraNumber
+from app.data import Pseudonym, UraNumber
 from app.db.decorator import repository
 from app.db.models.referral import ReferralEntity
 from app.db.repository.respository_base import RepositoryBase
@@ -11,10 +11,10 @@ from app.db.repository.respository_base import RepositoryBase
 
 @repository(ReferralEntity)
 class ReferralRepository(RepositoryBase):
-    def find_one(self, pseudonym: Pseudonym, data_domain: DataDomain, ura_number: UraNumber) -> ReferralEntity | None:
+    def find_one(self, pseudonym: Pseudonym, data_domain: str, ura_number: UraNumber) -> ReferralEntity | None:
         stmt = select(ReferralEntity).where(
             ReferralEntity.ura_number == str(ura_number),
-            ReferralEntity.data_domain == str(data_domain),
+            ReferralEntity.data_domain == data_domain,
             ReferralEntity.pseudonym == str(pseudonym),
         )
         result = self.db_session.execute(stmt).scalars().first()
@@ -27,7 +27,7 @@ class ReferralRepository(RepositoryBase):
     def query_referrals(
         self,
         pseudonym: Pseudonym | None,
-        data_domain: DataDomain | None,
+        data_domain: str | None,
         ura_number: UraNumber | None,
     ) -> List[ReferralEntity]:
         stmt = select(ReferralEntity)

--- a/app/response_models/referrals.py
+++ b/app/response_models/referrals.py
@@ -2,22 +2,17 @@ from typing import Any, Optional
 
 from pydantic import BaseModel, field_serializer, field_validator
 
-from app.data import DataDomain, Pseudonym, UraNumber
+from app.data import Pseudonym, UraNumber
 
 
 class ReferralRequest(BaseModel):
     pseudonym: Pseudonym
-    data_domain: DataDomain
+    data_domain: str
 
     @field_validator("pseudonym", mode="before")
     @classmethod
     def serialize_pseudonym(cls, val: str) -> Pseudonym:
         return Pseudonym(val)
-
-    @field_validator("data_domain", mode="before")
-    @classmethod
-    def serialize_dd(cls, val: str) -> DataDomain:
-        return DataDomain(val)
 
 
 class ReferralRequestHeader(BaseModel):
@@ -26,7 +21,7 @@ class ReferralRequestHeader(BaseModel):
 
 class CreateReferralRequest(BaseModel):
     pseudonym: Pseudonym
-    data_domain: DataDomain
+    data_domain: str
     ura_number: UraNumber
     requesting_uzi_number: str
 
@@ -34,11 +29,6 @@ class CreateReferralRequest(BaseModel):
     @classmethod
     def serialize_pseudo(cls, val: str) -> Pseudonym:
         return Pseudonym(val)
-
-    @field_validator("data_domain", mode="before")
-    @classmethod
-    def serialize_dd(cls, val: str) -> DataDomain:
-        return DataDomain(val)
 
     @field_validator("ura_number", mode="before")
     @classmethod
@@ -52,16 +42,12 @@ class DeleteReferralRequest(CreateReferralRequest):
 
 class ReferralEntry(BaseModel):
     pseudonym: Pseudonym
-    data_domain: DataDomain
+    data_domain: str
     ura_number: UraNumber
 
     @field_serializer("ura_number")
     def serialize_pi(self, ura_number: UraNumber) -> str:
         return str(ura_number)
-
-    @field_serializer("data_domain")
-    def serialize_dd(self, data_domain: DataDomain, _info: Any) -> str:
-        return str(data_domain)
 
     @field_serializer("pseudonym")
     def serialize_ps(self, pseudonym: Pseudonym, _info: Any) -> str:
@@ -70,18 +56,13 @@ class ReferralEntry(BaseModel):
 
 class ReferralQuery(BaseModel):
     pseudonym: Optional[Pseudonym] = None
-    data_domain: Optional[DataDomain] = None
+    data_domain: Optional[str] = None
     ura_number: UraNumber
 
     @field_validator("pseudonym", mode="before")
     @classmethod
     def serialize_pseudo(cls, val: Optional[str]) -> Optional[Pseudonym]:
         return None if val is None else Pseudonym(val)
-
-    @field_validator("data_domain", mode="before")
-    @classmethod
-    def serialize_dd(cls, val: Optional[str]) -> Optional[DataDomain]:
-        return None if val is None else DataDomain(val)
 
     @field_validator("ura_number", mode="before")
     @classmethod

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,13 +1,6 @@
 import unittest
 
-from app.data import DataDomain, Pseudonym, UraNumber
-
-
-class TestDataDomain(unittest.TestCase):
-    def test_careplan(self) -> None:
-        self.assertEqual("zorgplan", str(DataDomain.CarePlan))
-        self.assertEqual(DataDomain.CarePlan, DataDomain.from_fhir("CarePlan"))
-        self.assertEqual("CarePlan", DataDomain.CarePlan.to_fhir())
+from app.data import Pseudonym, UraNumber
 
 
 class TestPseudonym(unittest.TestCase):

--- a/tests/test_referral_service.py
+++ b/tests/test_referral_service.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from fastapi import HTTPException
 
-from app.data import DataDomain, Pseudonym, UraNumber
+from app.data import Pseudonym, UraNumber
 from app.db.db import Database
 from app.response_models.referrals import ReferralEntry
 from app.services.authorization_services.stub import StubAuthService
@@ -30,7 +30,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         self.referral_service.add_one_referral(
@@ -45,7 +45,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         with self.assertRaises(HTTPException) as context:
@@ -63,7 +63,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         self.referral_service.add_one_referral(
@@ -88,7 +88,7 @@ class ReferralServiceTest(TestCase):
         with self.assertRaises(HTTPException) as context:
             self.referral_service.get_referrals_by_domain_and_pseudonym(
                 pseudonym=Pseudonym(str(uuid4())),
-                data_domain=DataDomain.ImagingStudy,
+                data_domain="ImagingStudy",
                 client_ura_number=UraNumber("12341234"),
             )
         self.assertEqual(context.exception.status_code, 404)
@@ -97,7 +97,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         self.referral_service.add_one_referral(
@@ -137,7 +137,7 @@ class ReferralServiceTest(TestCase):
         with self.assertRaises(HTTPException) as context:
             self.referral_service.delete_one_referral(
                 pseudonym=Pseudonym(str(uuid4())),
-                data_domain=DataDomain.ImagingStudy,
+                data_domain="ImagingStudy",
                 ura_number=UraNumber("99999"),
                 request_url="https://test",
             )
@@ -147,7 +147,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         self.referral_service.add_one_referral(
@@ -173,7 +173,7 @@ class ReferralServiceTest(TestCase):
         mock_referral = ReferralEntry(
             ura_number=UraNumber("12345"),
             pseudonym=Pseudonym("6d87d96a-cb78-4f5c-823b-578095da2c4a"),
-            data_domain=DataDomain.ImagingStudy,
+            data_domain="ImagingStudy",
         )
 
         self.referral_service.add_one_referral(
@@ -221,7 +221,7 @@ class ReferralServiceTest(TestCase):
             _ = self.referral_service.query_referrals(
                 pseudonym=None,
                 ura_number=UraNumber("99999"),
-                data_domain=DataDomain.MedicationStatement,
+                data_domain="MedicationStatement",
                 request_url="http://test",
             )
         self.assertEqual(context.exception.status_code, 404)


### PR DESCRIPTION
- removed 'DataDomain' definitions from application and replaced it with open strings so that client app can write according to FhirResource

part of [Issue 68](https://github.com/minvws/gfmodules-nationale-verwijsindex-registratie-service-private/issues/68)