### PR TITLE
refactor: split up device implementation from NVIReference route

### DIFF
--- a/app/models/fhir/resources/data.py
+++ b/app/models/fhir/resources/data.py
@@ -1,7 +1,7 @@
 from typing import Final
 
-ORG_SYSTEM: Final[str] = "urn:oid:2.16.528.1.1007.3.3"  # NOSONAR
-ORG_TYPE_SYSTEM: Final[str] = "https://nvi.proeftuin.gf.irealisatie.nl/fhir/CodeSystem/nvi-organization-types"
+SOURCE_SYSTEM: Final[str] = "urn:oid:2.16.528.1.1007.3.3"  # NOSONAR
+SOURCE_TYPE_SYSTEM: Final[str] = "https://nvi.proeftuin.gf.irealisatie.nl/fhir/CodeSystem/nvi-organization-types"
 SUBJECT_SYSTEM: Final[str] = "https://nvi.proeftuin.gf.irealisatie.nl/fhir/NamingSystem/nvi-pseudonym"
 CARE_CONTEXT_SYSTEM: Final[str] = "https://nvi.proeftuin.gf.irealisatie.nl/fhir/CodeSystem/care-context-type"
-SOURCE_SYSTEM: Final[str] = "https://nvi.proeftuin.gf.irealisatie.nl/fhir/CodeSystem/source-type"
+DEFAULT_DEVICE_IDENTIFIER: Final[str] = "default-device"

--- a/app/models/fhir/resources/data_reference/resource.py
+++ b/app/models/fhir/resources/data_reference/resource.py
@@ -9,9 +9,8 @@ from app.models.data_domain import DataDomain
 from app.models.fhir.elements import CodeableConcept, Coding, Identifier
 from app.models.fhir.resources.data import (
     CARE_CONTEXT_SYSTEM,
-    ORG_SYSTEM,
-    ORG_TYPE_SYSTEM,
     SOURCE_SYSTEM,
+    SOURCE_TYPE_SYSTEM,
     SUBJECT_SYSTEM,
 )
 from app.models.fhir.resources.domain_resource import DomainResource
@@ -22,56 +21,55 @@ class NVIDataReferenceBase(BaseModel):
     model_config = ConfigDict(alias_generator=to_camel, populate_by_name=True)
 
     resource_type: Literal["NVIDataReference"] = "NVIDataReference"
-    organization: Identifier
-    organization_type: CodeableConcept
-    care_context: CodeableConcept
     source: Identifier
+    source_type: CodeableConcept
+    care_context: CodeableConcept
 
-    @field_validator("organization", mode="before")
+    @field_validator("source", mode="before")
     @classmethod
-    def validate_organization(cls, value: Any) -> Identifier:
+    def validate_source(cls, value: Any) -> Identifier:
         if value is None:
             raise ValueError("NVIDataReference.source is required")
 
         try:
-            organization = Identifier.model_validate(value)
+            source = Identifier.model_validate(value)
         except ValidationError:
-            raise ValueError("NVIDataReferece.organization must be a valid `Identifier`")
+            raise ValueError("NVIDataReferece.source must be a valid `Identifier`")
 
-        if organization.system != ORG_SYSTEM:
-            raise ValueError(f"NVIDataReferece.organization.system unrecognized, system must be: {ORG_SYSTEM}")
+        if source.system != SOURCE_SYSTEM:
+            raise ValueError(f"NVIDataReferece.source.system unrecognized, system must be: {SOURCE_SYSTEM}")
 
         try:
-            UraNumber(organization.value)
+            UraNumber(source.value)
         except ValueError as e:
             raise ValueError(f"Invalid UraNumber: {e}")
 
-        return organization
+        return source
 
-    @field_validator("organization_type", mode="before")
+    @field_validator("source_type", mode="before")
     @classmethod
-    def validate_org_type(cls, value: Any) -> CodeableConcept:
+    def validate_source_type(cls, value: Any) -> CodeableConcept:
         if value is None:
             raise ValueError("NVIDataReference.organizationType is required")
 
         try:
-            org_type = CodeableConcept.model_validate(value)
+            source_type = CodeableConcept.model_validate(value)
         except ValidationError:
             raise ValueError("NVIDataReferece.sourceType must be a valid `CodeableConcept`")
 
-        if len(org_type.coding) != 1:
+        if len(source_type.coding) != 1:
             raise ValueError("NVIDataReference.sourceType.coding must me of length `1`")
 
-        coding = org_type.coding[0]
+        coding = source_type.coding[0]
 
-        if coding.system != ORG_TYPE_SYSTEM:
+        if coding.system != SOURCE_TYPE_SYSTEM:
             raise ValueError(
-                f"NVIDataReference.sourceType.coding.system urecognized, system must be: {ORG_TYPE_SYSTEM}"
+                f"NVIDataReference.sourceType.coding.system urecognized, system must be: {SOURCE_TYPE_SYSTEM}"
             )
         if coding.code not in [types.code for types in NVI_ORGANIZATION_TYPES]:
             raise ValueError(f"Invalid SourceType code: '{coding.code}' is not in ValueSet nvi-organization-types")
 
-        return org_type
+        return source_type
 
     @field_validator("care_context", mode="before")
     @classmethod
@@ -99,33 +97,14 @@ class NVIDataReferenceBase(BaseModel):
 
         return care_context
 
-    @field_validator("source", mode="before")
-    @classmethod
-    def validate_source(cls, value: Any) -> Identifier:
-        if value is None:
-            raise ValueError("NVIDataReference.source is required")
-
-        try:
-            source = Identifier.model_validate(value)
-        except ValidationError:
-            raise ValueError("NVIDataReference.source must be a valid Identifier")
-
-        if source.system != SOURCE_SYSTEM:
-            raise ValueError(f"NVI.source.system unrecognized, system must be {SOURCE_SYSTEM}")
-
-        return source
-
     def get_ura_number(self) -> UraNumber:
-        return UraNumber(self.organization.value)
+        return UraNumber(self.source.value)
 
     def get_data_domain(self) -> DataDomain:
         return DataDomain(self.care_context.coding[0].code)
 
     def get_organization_type(self) -> str:
-        return self.organization_type.coding[0].code
-
-    def get_source(self) -> str:
-        return self.source.value
+        return self.source_type.coding[0].code
 
 
 class NVIDataRefrenceInput(NVIDataReferenceBase):
@@ -154,14 +133,14 @@ class NVIDataReferenceOutput(NVIDataReferenceBase, DomainResource):
     def from_referral(cls, entity: ReferralEntity) -> "NVIDataReferenceOutput":
         return cls(
             id=entity.id,
-            organization=Identifier(
-                system=ORG_SYSTEM,
+            source=Identifier(
+                system=SOURCE_SYSTEM,
                 value=entity.ura_number,
             ),
-            organization_type=CodeableConcept(
+            source_type=CodeableConcept(
                 coding=[
                     Coding(
-                        system=ORG_TYPE_SYSTEM,
+                        system=SOURCE_TYPE_SYSTEM,
                         code=entity.organization_type,
                         display=next(
                             (
@@ -186,5 +165,4 @@ class NVIDataReferenceOutput(NVIDataReferenceBase, DomainResource):
                     )
                 ]
             ),
-            source=Identifier(system=SOURCE_SYSTEM, value=entity.source),
         )

--- a/app/models/fhir/resources/organization/resource.py
+++ b/app/models/fhir/resources/organization/resource.py
@@ -5,7 +5,7 @@ from pydantic.alias_generators import to_camel
 
 from app.db.models.referral import ReferralEntity
 from app.models.fhir.elements import CodeableConcept, Coding, Identifier
-from app.models.fhir.resources.data import ORG_TYPE_SYSTEM, SOURCE_SYSTEM
+from app.models.fhir.resources.data import SOURCE_SYSTEM, SOURCE_TYPE_SYSTEM
 from app.models.fhir.resources.domain_resource import DomainResource
 
 
@@ -22,7 +22,7 @@ class Organization(DomainResource):
         org_type = CodeableConcept(
             coding=[
                 Coding(
-                    system=ORG_TYPE_SYSTEM,
+                    system=SOURCE_TYPE_SYSTEM,
                     code=referral.organization_type,
                     display=referral.organization_type.capitalize(),
                 )

--- a/app/routers/data_reference.py
+++ b/app/routers/data_reference.py
@@ -11,9 +11,9 @@ from app.models.data_domain import DataDomain
 from app.models.fhir.bundle import Bundle
 from app.models.fhir.resources.data import (
     CARE_CONTEXT_SYSTEM,
-    ORG_SYSTEM,
-    ORG_TYPE_SYSTEM,
+    DEFAULT_DEVICE_IDENTIFIER,
     SOURCE_SYSTEM,
+    SOURCE_TYPE_SYSTEM,
     SUBJECT_SYSTEM,
 )
 from app.models.fhir.resources.data_reference.requests import DataReferenceRequestParams
@@ -73,22 +73,18 @@ def exchange_oprf(pseudonym_service: PseudonymService, oprf_jwe: str, blind_fact
                                     "versionId": "1",
                                     "lastUpdated": "2024-12-08T14:40:00Z",
                                 },
-                                "organization": {
-                                    "system": ORG_SYSTEM,
+                                "source": {
+                                    "system": SOURCE_SYSTEM,
                                     "value": "90000001",
                                 },
-                                "organization_type": {
+                                "sourceType": {
                                     "coding": [
                                         {
-                                            "system": ORG_TYPE_SYSTEM,
+                                            "system": SOURCE_TYPE_SYSTEM,
                                             "code": "laboratorium",
                                             "display": "Laboratorium",
                                         }
                                     ]
-                                },
-                                "source": {
-                                    "system": SOURCE_SYSTEM,
-                                    "value": "Electronic Health Record System",
                                 },
                                 "careContext": {
                                     "coding": [
@@ -141,7 +137,7 @@ def get_reference(
     registrations = referral_service.get_registrations(
         ura_number=UraNumber(params.source),
         pseudonym=pseudonym,
-        source=params.source,
+        source=DEFAULT_DEVICE_IDENTIFIER,
         data_domain=DataDomain(params.care_context) if params.care_context else None,
     )
     return Bundle.from_reference_outputs(registrations)
@@ -194,12 +190,12 @@ def delete_reference(
                 pseudonym=pseudonym,
             )
             return DeleteResponse(status_code=204)
-        if params.source and params.care_context:
+        else:
             referral_service.delete_specific_registration(
                 ura_number=UraNumber(params.organization),
                 data_domain=DataDomain(params.care_context),
                 pseudonym=pseudonym,
-                source=params.source,
+                source=DEFAULT_DEVICE_IDENTIFIER,
             )
 
             return DeleteResponse(status_code=204)
@@ -229,20 +225,19 @@ def delete_reference(
                                 "versionId": "1",
                                 "lastUpdated": "2024-12-08T14:40:00Z",
                             },
-                            "organization": {
-                                "system": ORG_TYPE_SYSTEM,
+                            "source": {
+                                "system": SOURCE_TYPE_SYSTEM,
                                 "value": "90000001",
                             },
-                            "organization_typeType": {
+                            "sourceType": {
                                 "coding": [
                                     {
-                                        "system": ORG_TYPE_SYSTEM,
+                                        "system": SOURCE_TYPE_SYSTEM,
                                         "code": "laboratorium",
                                         "display": "Laboratorium",
                                     }
                                 ]
                             },
-                            "source": {"system": SOURCE_SYSTEM, "value": "DeviceName"},
                             "careContext": {
                                 "coding": [
                                     {
@@ -276,20 +271,19 @@ def delete_reference(
                                 "versionId": "1",
                                 "lastUpdated": "2024-12-08T14:40:00Z",
                             },
-                            "organization": {
-                                "system": ORG_SYSTEM,
+                            "source": {
+                                "system": SOURCE_SYSTEM,
                                 "value": "90000001",
                             },
-                            "organizationType": {
+                            "sourceType": {
                                 "coding": [
                                     {
-                                        "system": ORG_TYPE_SYSTEM,
+                                        "system": SOURCE_TYPE_SYSTEM,
                                         "code": "laboratorium",
                                         "display": "Laboratorium",
                                     }
                                 ]
                             },
-                            "source": {"system": SOURCE_SYSTEM, "value": "DeviceValue"},
                             "careContext": {
                                 "coding": [
                                     {
@@ -323,16 +317,15 @@ def create_reference(
                         "system": SUBJECT_SYSTEM,
                         "value": "eyJhbGciOiJSU0EtT0FFUC0yNTYiLCJlbmMiOiJBMjU2R0NNIn0...",
                     },
-                    "organization": {"system": ORG_SYSTEM, "value": "90000001"},
-                    "organizationType": {
+                    "source": {"system": SOURCE_SYSTEM, "value": "90000001"},
+                    "sourceType": {
                         "coding": [
                             {
-                                "system": ORG_TYPE_SYSTEM,
+                                "system": SOURCE_TYPE_SYSTEM,
                                 "code": "laboratorium",
                             }
                         ]
                     },
-                    "source": {"system": SOURCE_SYSTEM, "value": "DeviceValue"},
                     "careContext": {
                         "coding": [
                             {
@@ -373,7 +366,7 @@ def create_reference(
         pseudonym=pseudonym,
         data_domain=data.get_data_domain(),
         ura_number=data.get_ura_number(),
-        source=data.get_source(),
+        source=DEFAULT_DEVICE_IDENTIFIER,
     )
     if referral:
         return FHIRJSONResponse(
@@ -386,7 +379,7 @@ def create_reference(
         data_domain=data.get_data_domain(),
         ura_number=data.get_ura_number(),
         organization_type=data.get_organization_type(),
-        source=data.get_source(),
+        source=DEFAULT_DEVICE_IDENTIFIER,
     )
     return FHIRJSONResponse(
         content=jsonable_encoder(new_reference.model_dump(exclude_none=True, by_alias=True)),
@@ -422,7 +415,7 @@ def create_reference(
                         "sourceType": {
                             "coding": [
                                 {
-                                    "system": ORG_TYPE_SYSTEM,
+                                    "system": SOURCE_TYPE_SYSTEM,
                                     "code": "laboratorium",
                                     "display": "Laboratorium",
                                 }

--- a/app/routers/organization.py
+++ b/app/routers/organization.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Body, Depends
 from app.dependencies import get_organization_service, get_pseudonym_service
 from app.exceptions.fhir_exception import FHIRException, OperationOutcome
 from app.models.fhir.bundle import Bundle
-from app.models.fhir.resources.data import CARE_CONTEXT_SYSTEM, ORG_SYSTEM
+from app.models.fhir.resources.data import CARE_CONTEXT_SYSTEM, SOURCE_SYSTEM
 from app.models.fhir.resources.organization.parameters import Parameters
 from app.models.fhir.resources.organization.resource import Organization
 from app.models.response import FHIRJSONResponse
@@ -40,7 +40,7 @@ router = APIRouter(tags=["Organization"], prefix="/Organization")
                                 "resource": {
                                     "resourceType": "Organization",
                                     "id": "90000001",
-                                    "identifier": [{"system": ORG_SYSTEM, "value": "90000001"}],
+                                    "identifier": [{"system": SOURCE_SYSTEM, "value": "90000001"}],
                                 }
                             }
                         ],

--- a/tests/models/fhir/data_reference/test_resource.py
+++ b/tests/models/fhir/data_reference/test_resource.py
@@ -6,9 +6,8 @@ from app.db.models.referral import ReferralEntity
 from app.models.fhir.elements import CodeableConcept, Coding, Identifier
 from app.models.fhir.resources.data import (
     CARE_CONTEXT_SYSTEM,
-    ORG_SYSTEM,
-    ORG_TYPE_SYSTEM,
     SOURCE_SYSTEM,
+    SOURCE_TYPE_SYSTEM,
     SUBJECT_SYSTEM,
 )
 from app.models.fhir.resources.data_reference.resource import (
@@ -19,18 +18,16 @@ from app.models.fhir.resources.data_reference.resource import (
 
 def test_serialize_nvi_data_reference_input_should_succeed() -> None:
     data = NVIDataRefrenceInput(
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
         care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
         subject=Identifier(system=SUBJECT_SYSTEM, value="some-jwe"),
         oprf_key="some-key",
     )
     expected = {
         "resourceType": "NVIDataReference",
-        "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-        "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
-        "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
+        "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -43,18 +40,16 @@ def test_serialize_nvi_data_reference_input_should_succeed() -> None:
 
 def test_deserialize_nvi_data_reference_input_should_succeed() -> None:
     expected = NVIDataRefrenceInput(
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
         care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
         subject=Identifier(system=SUBJECT_SYSTEM, value="some-jwe"),
         oprf_key="some-key",
     )
     data = {
-        "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-        "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
-        "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
     }
@@ -68,17 +63,15 @@ def test_serialize_nvi_data_reference_output_should_succeed() -> None:
     resource_id = uuid4()
     data = NVIDataReferenceOutput(
         id=resource_id,
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
         care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
     )
     expected = {
         "id": resource_id,
         "resourceType": "NVIDataReference",
-        "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-        "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
-        "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
+        "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
     }
 
@@ -91,16 +84,14 @@ def test_deserialize_nvi_data_reference_output_should_succeed() -> None:
     resource_id = uuid4()
     expected = NVIDataReferenceOutput(
         id=resource_id,
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
         care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
     )
     data = {
         "id": resource_id,
-        "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-        "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
-        "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
+        "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
     }
 
@@ -112,7 +103,7 @@ def test_deserialize_nvi_data_reference_output_should_succeed() -> None:
 def test_create_nvi_data_reference_input_shoulf_fail_when_source_is_abscent() -> None:
     data = {
         "id": uuid4(),
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -126,7 +117,7 @@ def test_create_nvi_data_reference_input_should_fail_with_incorrect_source() -> 
     data = {
         "id": uuid4(),
         "source": {"system": "WRONG SOURCE", "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -140,7 +131,7 @@ def test_create_nvi_data_reference_input_should_fail_when_source_is_not_identifi
     data = {
         "id": uuid4(),
         "source": {"WRONG_PROPETY": "some-value"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
     }
     with pytest.raises(ValueError):
@@ -162,7 +153,7 @@ def test_create_nvi_data_reference_input_should_fail_when_organization_type_is_n
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"WRONG_PROPETY": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"WRONG_PROPETY": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
     }
     with pytest.raises(ValueError):
@@ -175,8 +166,8 @@ def test_create_nvi_data_reference_should_fail_when_more_than_one_value_in_organ
         "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
         "sourceType": {
             "coding": [
-                {"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"},
-                {"system": ORG_TYPE_SYSTEM, "code": "Pharmacy"},
+                {"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"},
+                {"system": SOURCE_TYPE_SYSTEM, "code": "Pharmacy"},
             ]
         },
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
@@ -203,7 +194,7 @@ def test_create_nvi_data_reference_should_fail_care_context_is_abscent() -> None
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
     }
@@ -215,7 +206,7 @@ def test_create_nvi_data_reference_should_fail_when_care_context_is_not_codeable
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"WRONG_PROPETY": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -228,7 +219,7 @@ def test_create_nvi_data_reference_should_fail_when_care_context_has_more_than_o
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {
             "coding": [
                 {"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"},
@@ -246,7 +237,7 @@ def test_create_nvi_data_reference_should_fail_when_care_context_has_wrong_syste
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": "WRONG SYSTEM", "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -260,7 +251,7 @@ def test_create_nvi_data_reference_input_should_fail_when_subject_is_abscent() -
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "oprfKey": "some-key",
     }
@@ -272,7 +263,7 @@ def test_create_nvi_data_reference_input_should_fail_when_subject_is_not_identif
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"WRONG_PROPERTY": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -285,7 +276,7 @@ def test_create_nvi_data_reference_input_should_fail_when_subject_has_wrong_syst
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": "WRONG SYSTEM", "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -298,7 +289,7 @@ def test_create_nvi_data_reference_input_should_fail_with_invalid_ura_number() -
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "INVALID_URA_NUMBER_WITH_CHARS"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -324,7 +315,7 @@ def test_nvi_data_reference_input_from_entity_should_fail_with_invalid_organizat
     data = {
         "id": uuid4(),
         "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
-        "sourceType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "INVALID_ORGANIZATION_TYPE"}]},
+        "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "INVALID_ORGANIZATION_TYPE"}]},
         "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
         "subject": {"system": SUBJECT_SYSTEM, "value": "some-jwe"},
         "oprfKey": "some-key",
@@ -338,11 +329,10 @@ def test_from_entity_should_succeed() -> None:
     resource_id = uuid4()
     expected = NVIDataReferenceOutput(
         id=resource_id,
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(
-            coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis", display="Ziekenhuis")]
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(
+            coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis", display="Ziekenhuis")]
         ),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
         care_context=CodeableConcept(
             coding=[
                 Coding(

--- a/tests/models/fhir/test_bundle.py
+++ b/tests/models/fhir/test_bundle.py
@@ -5,9 +5,8 @@ from app.models.fhir.bundle import Bundle, BundleEntry
 from app.models.fhir.elements import CodeableConcept, Coding, Identifier
 from app.models.fhir.resources.data import (
     CARE_CONTEXT_SYSTEM,
-    ORG_SYSTEM,
-    ORG_TYPE_SYSTEM,
     SOURCE_SYSTEM,
+    SOURCE_TYPE_SYSTEM,
 )
 from app.models.fhir.resources.data_reference.resource import (
     NVIDataReferenceOutput,
@@ -28,9 +27,8 @@ def test_serialize_should_succeed() -> None:
                 "resource": {
                     "id": resource_id,
                     "resourceType": "NVIDataReference",
-                    "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-                    "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
-                    "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
+                    "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+                    "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
                     "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
                 }
             }
@@ -44,9 +42,8 @@ def test_serialize_should_succeed() -> None:
             BundleEntry(
                 resource=NVIDataReferenceOutput(
                     id=resource_id,
-                    organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-                    source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
-                    organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
+                    source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+                    source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
                     care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
                 )
             )
@@ -70,9 +67,8 @@ def test_deserialize_should_succeed() -> None:
             {
                 "resource": {
                     "id": resource_id,
-                    "organization": {"system": ORG_SYSTEM, "value": "00000123"},
-                    "organizationType": {"coding": [{"system": ORG_TYPE_SYSTEM, "code": "ziekenhuis"}]},
-                    "source": {"system": SOURCE_SYSTEM, "value": "SomeDevice"},
+                    "source": {"system": SOURCE_SYSTEM, "value": "00000123"},
+                    "sourceType": {"coding": [{"system": SOURCE_TYPE_SYSTEM, "code": "ziekenhuis"}]},
                     "careContext": {"coding": [{"system": CARE_CONTEXT_SYSTEM, "code": "ImagingStudy"}]},
                 }
             }
@@ -85,9 +81,8 @@ def test_deserialize_should_succeed() -> None:
             BundleEntry(
                 resource=NVIDataReferenceOutput(
                     id=resource_id,
-                    organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-                    organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
-                    source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
+                    source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+                    source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
                     care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
                 )
             )
@@ -103,9 +98,8 @@ def test_from_reference_output_should_succeed() -> None:
     bundle_id = uuid4()
     output = NVIDataReferenceOutput(
         id=uuid4(),
-        organization=Identifier(system=ORG_SYSTEM, value="00000123"),
-        organization_type=CodeableConcept(coding=[Coding(system=ORG_TYPE_SYSTEM, code="ziekenhuis")]),
-        source=Identifier(system=SOURCE_SYSTEM, value="SomeDevice"),
+        source=Identifier(system=SOURCE_SYSTEM, value="00000123"),
+        source_type=CodeableConcept(coding=[Coding(system=SOURCE_TYPE_SYSTEM, code="ziekenhuis")]),
         care_context=CodeableConcept(coding=[Coding(system=CARE_CONTEXT_SYSTEM, code="ImagingStudy")]),
     )
     expected = Bundle(total=1, entry=[BundleEntry(resource=output)], id=str(bundle_id))


### PR DESCRIPTION
- split up NVIDataReference implementation from device
- added a default_device constant for mapping to referrals in NVIDataReferences route.
- fixed tests 