### PR TITLE
Return invalid request when pseudonym request is incorrect

### DIFF
--- a/app/routers/data_reference.py
+++ b/app/routers/data_reference.py
@@ -26,6 +26,7 @@ from app.models.pseudonym import Pseudonym
 from app.models.response import DeleteResponse, FHIRJSONResponse
 from app.models.ura import UraNumber
 from app.services.oauth import OAuthService
+from app.services.prs.exception import PseudonymError
 from app.services.prs.pseudonym_service import PseudonymService
 from app.services.referral_service import ReferralService
 
@@ -36,6 +37,15 @@ router = APIRouter(tags=["NVI Data Reference"], prefix="/NVIDataReference")
 def exchange_oprf(pseudonym_service: PseudonymService, oprf_jwe: str, blind_factor: str) -> Pseudonym:
     try:
         return pseudonym_service.exchange(oprf_jwe=oprf_jwe, blind_factor=blind_factor)
+    except PseudonymError as e:
+        logger.error(f"invalid pseudonym exchange request: {e}")
+        raise FHIRException(
+            status_code=400,
+            severity="error",
+            code="invalid",
+            msg="Invalid pseudonym request",
+            expression=["NVIDataReference.subject"],
+        ) from e
     except Exception as e:
         logger.error(f"failed to exchange pseudonym: {e}")
         raise FHIRException(

--- a/app/routers/organization.py
+++ b/app/routers/organization.py
@@ -12,6 +12,7 @@ from app.models.fhir.resources.organization.parameters import Parameters
 from app.models.fhir.resources.organization.resource import Organization
 from app.models.response import FHIRJSONResponse
 from app.services.organization import OrganizationService
+from app.services.prs.exception import PseudonymError
 from app.services.prs.pseudonym_service import PseudonymService
 
 logger = logging.getLogger(__name__)
@@ -94,6 +95,15 @@ def localize(
         localisation_pseudonym = pseudonym_service.exchange(
             oprf_jwe=localization_dto.oprf_jwe, blind_factor=localization_dto.oprf_key
         )
+    except PseudonymError as e:
+        logger.error(f"Invalid pseudonym exchange request: {e}")
+        raise FHIRException(
+            status_code=400,
+            severity="error",
+            code="invalid",
+            msg="Invalid pseudonym request",
+            expression=["Parameters.parameter.pseudonym"],
+        ) from e
     except Exception as e:
         logger.error(f"Failed to exchange pseudonym: {e}")
         raise FHIRException(

--- a/app/services/prs/pseudonym_service.py
+++ b/app/services/prs/pseudonym_service.py
@@ -4,7 +4,7 @@ import logging
 import pyoprf
 
 from app.models.pseudonym import Pseudonym
-from app.services.decrypt_service import DecryptService
+from app.services.decrypt_service import DecryptError, DecryptService
 from app.services.prs.exception import PseudonymError
 
 logger = logging.getLogger(__name__)
@@ -24,7 +24,10 @@ class PseudonymService:
         logger.info("Decrypting OPRF JWE")
 
         # Decrypt OPRF-JWE<NVI> with private key pre-registered at PRS
-        jwe_data = self._decrypt_service.decrypt_jwe(oprf_jwe)
+        try:
+            jwe_data = self._decrypt_service.decrypt_jwe(oprf_jwe)
+        except DecryptError as e:
+            raise PseudonymError("Invalid pseudonym request") from e
 
         if jwe_data["subject"].startswith("pseudonym:eval:") is False:
             logger.error("JWE is invalid: subject does not start with pseudonym:eval:")

--- a/tests/services/test_data_reference_router.py
+++ b/tests/services/test_data_reference_router.py
@@ -1,0 +1,62 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.exceptions.fhir_exception import FHIRException
+from app.models.pseudonym import Pseudonym
+from app.routers.data_reference import exchange_oprf
+from app.services.prs.exception import PseudonymError
+from app.services.prs.pseudonym_service import PseudonymService
+
+
+def test_exchange_oprf_should_raise_400_when_pseudonym_request_is_invalid() -> None:
+    pseudonym_service = MagicMock(spec=PseudonymService)
+    pseudonym_service.exchange.side_effect = PseudonymError("Invalid pseudonym request")
+
+    with pytest.raises(FHIRException) as exc:
+        exchange_oprf(
+            pseudonym_service=pseudonym_service,
+            oprf_jwe="invalid-jwe",
+            blind_factor="invalid-oprf-key",
+        )
+
+    detail = cast(dict[str, Any], exc.value.detail)
+    issue = detail["issue"][0]
+    assert exc.value.status_code == 400
+    assert issue["code"] == "invalid"
+    assert issue["details"]["text"] == "Invalid pseudonym request"
+    assert issue["expression"] == ["NVIDataReference.subject"]
+
+
+def test_exchange_oprf_should_raise_500_when_pseudonym_exchange_fails_unexpectedly() -> None:
+    pseudonym_service = MagicMock(spec=PseudonymService)
+    pseudonym_service.exchange.side_effect = RuntimeError("unexpected failure")
+
+    with pytest.raises(FHIRException) as exc:
+        exchange_oprf(
+            pseudonym_service=pseudonym_service,
+            oprf_jwe="some-jwe",
+            blind_factor="some-oprf-key",
+        )
+
+    detail = cast(dict[str, Any], exc.value.detail)
+    issue = detail["issue"][0]
+    assert exc.value.status_code == 500
+    assert issue["code"] == "exception"
+    assert issue["details"]["text"] == "Pseudonym could not be exchanged"
+    assert issue["expression"] == ["NVIDataReference.subject"]
+
+
+def test_exchange_oprf_should_return_pseudonym_when_exchange_succeeds() -> None:
+    pseudonym_service = MagicMock(spec=PseudonymService)
+    expected = Pseudonym("expected-pseudonym")
+    pseudonym_service.exchange.return_value = expected
+
+    actual = exchange_oprf(
+        pseudonym_service=pseudonym_service,
+        oprf_jwe="valid-jwe",
+        blind_factor="valid-oprf-key",
+    )
+
+    assert actual == expected

--- a/tests/services/test_organization_router.py
+++ b/tests/services/test_organization_router.py
@@ -1,0 +1,75 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.exceptions.fhir_exception import FHIRException
+from app.models.fhir.resources.data import CARE_CONTEXT_SYSTEM
+from app.models.fhir.resources.organization.parameters import Parameters
+from app.routers.organization import localize
+from app.services.organization import OrganizationService
+from app.services.prs.exception import PseudonymError
+from app.services.prs.pseudonym_service import PseudonymService
+
+
+def _build_localize_parameters() -> Parameters:
+    return Parameters.model_validate(
+        {
+            "resourceType": "Parameters",
+            "parameter": [
+                {"name": "pseudonym", "valueString": "invalid-jwe"},
+                {"name": "oprfKey", "valueString": "invalid-oprf-key"},
+                {
+                    "name": "careContext",
+                    "valueCoding": {
+                        "system": CARE_CONTEXT_SYSTEM,
+                        "code": "MedicationAgreement",
+                    },
+                },
+            ],
+        }
+    )
+
+
+def test_localize_should_raise_400_when_pseudonym_request_is_invalid() -> None:
+    parameters = _build_localize_parameters()
+    pseudonym_service = MagicMock(spec=PseudonymService)
+    organization_service = MagicMock(spec=OrganizationService)
+    pseudonym_service.exchange.side_effect = PseudonymError("Invalid pseudonym request")
+
+    with pytest.raises(FHIRException) as exc:
+        localize(
+            parameters=parameters,
+            pseudonym_service=pseudonym_service,
+            organization_service=organization_service,
+        )
+
+    detail = cast(dict[str, Any], exc.value.detail)
+    issue = detail["issue"][0]
+    assert exc.value.status_code == 400
+    assert issue["code"] == "invalid"
+    assert issue["details"]["text"] == "Invalid pseudonym request"
+    assert issue["expression"] == ["Parameters.parameter.pseudonym"]
+    organization_service.get.assert_not_called()
+
+
+def test_localize_should_raise_500_when_pseudonym_exchange_fails_unexpectedly() -> None:
+    parameters = _build_localize_parameters()
+    pseudonym_service = MagicMock(spec=PseudonymService)
+    organization_service = MagicMock(spec=OrganizationService)
+    pseudonym_service.exchange.side_effect = RuntimeError("unexpected failure")
+
+    with pytest.raises(FHIRException) as exc:
+        localize(
+            parameters=parameters,
+            pseudonym_service=pseudonym_service,
+            organization_service=organization_service,
+        )
+
+    detail = cast(dict[str, Any], exc.value.detail)
+    issue = detail["issue"][0]
+    assert exc.value.status_code == 500
+    assert issue["code"] == "exception"
+    assert issue["details"]["text"] == "Pseudonym could not be exchanged"
+    assert issue["expression"] == ["Parameters.parameter.pseudonym"]
+    organization_service.get.assert_not_called()


### PR DESCRIPTION
Currently when the user sends an invalid JWE or not even a JWT the server responds with a 500 error. I think this should be an Bad Request.

Please add your review. 

Maybe we should create an `InvalidPseudonymException` that we can handle instead of the `PseudonymError`. Please let me know your opinions.