### PR TITLE
Add validation on pseudonym and oprf_key for DataReferenceRequestParams

### DIFF
--- a/app/models/fhir/resources/data_reference/requests.py
+++ b/app/models/fhir/resources/data_reference/requests.py
@@ -3,6 +3,7 @@ from pydantic import (
     ConfigDict,
     field_serializer,
     field_validator,
+    model_validator,
 )
 from pydantic.alias_generators import to_camel
 
@@ -33,3 +34,10 @@ class DataReferenceRequestParams(DataReferenceRequestBase):
     pseudonym: str | None = None
     oprf_key: str | None = None
     care_context: str | None = None
+
+    @model_validator(mode="after")
+    def validate_pseudonym_and_oprf_key_pair(self) -> "DataReferenceRequestParams":
+        if bool(self.pseudonym) != bool(self.oprf_key):
+            raise ValueError("pseudonym and oprfKey must both be provided")
+
+        return self

--- a/tests/models/fhir/data_reference/test_requests.py
+++ b/tests/models/fhir/data_reference/test_requests.py
@@ -50,3 +50,18 @@ def test_model_create_should_fail_with_str_ura() -> None:
 def test_model_create_should_fail_with_incorrect_ura_number_format() -> None:
     with pytest.raises(ValidationError):
         DataReferenceRequestParams(source="123456789191982")
+
+
+@pytest.mark.parametrize(
+    "pseudonym,oprf_key",
+    [
+        ("encrypted-subject", None),
+        (None, "some-oprf-key"),
+    ],
+)
+def test_model_create_should_fail_when_only_pseudonym_or_oprf_key_is_present(
+    pseudonym: str | None,
+    oprf_key: str | None,
+) -> None:
+    with pytest.raises(ValidationError):
+        DataReferenceRequestParams(source="00000123", pseudonym=pseudonym, oprf_key=oprf_key)


### PR DESCRIPTION
The `pseudonym` and `oprf_key` should exists both.