### PR TITLE
update pyjwt to recommended version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2072,14 +2072,14 @@ windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
 name = "pyjwt"
-version = "2.11.0"
+version = "2.12.1"
 description = "JSON Web Token implementation in Python"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469"},
-    {file = "pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623"},
+    {file = "pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c"},
+    {file = "pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b"},
 ]
 
 [package.extras]
@@ -3171,4 +3171,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "8a7f0609b6c48870cf71c8f0d21361db63ea5108701dde7608383b6cf6cbc26e"
+content-hash = "f5c21bbe2aee0d9c0273e7ea25f6da935456353b75ec002a5b1ab31e3dafd27a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = ["Ministerie van Volksgezondheid, Welzijn en Sport"]
 repository = "https://github.com/minvws/gfmodules-national-referral-index"
 readme = "README.md"
 packages = [{ include = "app" }]
-include = [{ path="static" }, { path="version.json" }]
+include = [{ path = "static" }, { path = "version.json" }]
 exclude = ["app/debug"]
 
 [tool.poetry.dependencies]
@@ -28,7 +28,7 @@ opentelemetry-instrumentation-requests = "^0.60b1"
 requests = "^2.32.5"
 statsd = "^4.0.1"
 puzi = { git = "https://github.com/minvws/puzi-python" }
-pyjwt = "^2.10.1"
+pyjwt = "^2.12.0"
 pyoprf = "0.9.3"
 jwcrypto = "^1.5.6"
 


### PR DESCRIPTION
fix vulnerability by updated to the recommended version:
```
Run make POETRY=true safety-check
poetry run pip-audit
Found 1 known vulnerability in 1 package
Name  Version ID             Fix Versions
----- ------- -------------- ------------
pyjwt 2.11.0  CVE-2026-32597 2.12.0
Name                              Skip Reason
--------------------------------- ------------------------------------------------------------------------------------------------
gfmodules-national-referral-index Dependency not found on PyPI and could not be audited: gfmodules-national-referral-index (0.1.0)
puzi                              Dependency not found on PyPI and could not be audited: puzi (0.1.0)
make: *** [Makefile:39: safety-check] Error 1
Error: Process completed with exit code 2.
``` 