### PR TITLE
Fix v1 query and delete with params subsumption-based logic

### DIFF
--- a/app/models/fhir/bundle.py
+++ b/app/models/fhir/bundle.py
@@ -22,7 +22,6 @@ class EntryRequestDto(BaseModel):
 
     @classmethod
     def from_url(cls, url: str) -> Self:
-
         parsed = urlparse(url)
         path_parts = parsed.path.strip("/").split("/")
 

--- a/app/models/fhir/elements.py
+++ b/app/models/fhir/elements.py
@@ -1,8 +1,11 @@
+import logging
 from typing import Any, List, Self
 
 from pydantic import model_validator
 
 from app.models.fhir.resources.domain_resource import FhirBaseModel
+
+logger = logging.getLogger(__name__)
 
 
 class Coding(FhirBaseModel):
@@ -14,7 +17,7 @@ class Coding(FhirBaseModel):
     @classmethod
     def validate_model(cls, value: Any) -> Any:
         if "code" not in value:
-            raise ValueError("Coding.system is required")
+            raise ValueError("Coding.code is required")
         code = value["code"]
         if not isinstance(code, str):
             raise ValueError("Coding.code must be of type `String`")
@@ -32,6 +35,20 @@ class Coding(FhirBaseModel):
 
         return value
 
+    @classmethod
+    def from_query(cls, query: str, system: str) -> Self:
+        data = query.split("|")
+        if len(data) == 1:
+            logger.debug(f"Parsing coding from query: {query} with implicit system: {system}")
+            return cls(system=system, code=query)
+        if len(data) != 2:
+            logger.debug(f"Invalid coding query format: {query}")
+            raise ValueError("Invalid query format, unable to determine System for Coding")
+        if data[0] and data[0] != system:
+            logger.debug(f"Unrecognized system in coding query: {query}")
+            raise ValueError(f"Unrecognized system, value must be {system}")
+        return cls(system=data[0], code=data[1])
+
 
 class CodeableConcept(FhirBaseModel):
     coding: List[Coding]
@@ -45,11 +62,15 @@ class Identifier(FhirBaseModel):
     @classmethod
     def from_query(cls, query: str, system: str) -> Self:
         data = query.split("|")
+        if len(data) == 1:
+            logger.debug(f"Parsing identifier from query: {query} with implicit system: {system}")
+            return cls(system=system, value=query)
         if len(data) != 2:
-            raise ValueError("Missing delimiter '|', unable to determine System for Identifier")
-        if data[0] != system:
+            logger.debug(f"Invalid identifier query format: {query}")
+            raise ValueError("Invalid query format, unable to determine System for Identifier")
+        if data[0] and data[0] != system:
+            logger.debug(f"Unrecognized system in identifier query: {query}")
             raise ValueError(f"Unrecognized system, value must be {system}")
-
         return cls(system=data[0], value=data[1])
 
 

--- a/app/models/fhir/elements.py
+++ b/app/models/fhir/elements.py
@@ -31,7 +31,7 @@ class Coding(FhirBaseModel):
         if "display" in value:
             display = value["display"]
             if not isinstance(display, str):
-                raise ValueError("Coding.display must be for type String")
+                raise ValueError("Coding.display must be of type String")
 
         return value
 

--- a/app/models/fhir/resources/localization_list/request.py
+++ b/app/models/fhir/resources/localization_list/request.py
@@ -1,7 +1,8 @@
 import logging
+from typing import Any
 
 from fastapi import Query
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 from app.models.fhir.elements import Coding, Identifier
 from app.models.fhir.resources.data import DATA_DOMAIN_SYSTEM, DEVICE_SYSTEM, PSEUDONYM_SYSTEM
@@ -10,41 +11,82 @@ from app.routers.v1.fhir import CODE_PARAM, DEVICE_IDENTIFIER_PARAM, SUBJECT_IDE
 logger = logging.getLogger(__name__)
 
 
-class LocalizationListParams(BaseModel):
-    subject: str | None = Query(alias=SUBJECT_IDENTIFIER_PARAM, example=f"{PSEUDONYM_SYSTEM}|identifier", default=None)
-    code: str | None = Query(alias=CODE_PARAM, example=f"{DATA_DOMAIN_SYSTEM}|code", default=None)
-    source: str | None = Query(alias=DEVICE_IDENTIFIER_PARAM, example=f"{DEVICE_SYSTEM}|identifier", default=None)
+def _create_openapi_examples(system: str) -> dict[str, Any]:
+    return {
+        "[code]": {
+            "value": "[code]",
+            "description": "the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property",
+        },
+        "[system]|[code]": {
+            "value": f"{system}|[code]",
+            "description": "the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding",
+        },
+        "|[code]": {
+            "value": "|[code]",
+            "description": "the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property (supported action but not applicable in our implementation since all our identifiers have a system, will not return any results)",
+        },
+        "[system]|": {
+            "value": f"{system}|",
+            "description": "any element where the value of [system] matches the system property of the Identifier or Coding (supported action but not applicable in our implementation since all our identifiers have a system, functions identically to leaving the field blank)",
+        },
+    }
 
-    def get_subject_identifier(self) -> str | None:
-        logger.debug(f"Parsing subject identifier from query: {self.subject}")
-        if self.subject is None:
+
+class LocalizationListParams(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    subject: str | None = Query(
+        alias=SUBJECT_IDENTIFIER_PARAM, openapi_examples=_create_openapi_examples(PSEUDONYM_SYSTEM), default=None
+    )
+    code: str | None = Query(
+        alias=CODE_PARAM, openapi_examples=_create_openapi_examples(DATA_DOMAIN_SYSTEM), default=None
+    )
+    source: str | None = Query(
+        alias=DEVICE_IDENTIFIER_PARAM, openapi_examples=_create_openapi_examples(DEVICE_SYSTEM), default=None
+    )
+
+    @field_validator("subject", mode="before")
+    @classmethod
+    def validate_subject(cls, value: str | None) -> str | None:
+        if value is None:
             return None
-        identifier = Identifier.from_query(query=self.subject, system=PSEUDONYM_SYSTEM)
-        logger.debug(f"Parsed subject identifier: system={identifier.system}, value={identifier.value}")
+        try:
+            identifier = Identifier.from_query(query=value, system=PSEUDONYM_SYSTEM)
+            logger.debug("Validated subject identifier: %r", identifier)
+        except ValueError as e:
+            raise ValueError(f"Invalid subject identifier: {e}")
         if not identifier.system or not identifier.value:
             # If system is left out e.g. "|12345" we don't return anything since our identifiers should always have a system: see https://r4.fhir.space/search.html#token
             return None
         return identifier.value
 
-    def get_source_identifier(self) -> str | None:
-        logger.debug(f"Parsing source identifier from query: {self.source}")
-        if self.source is None:
+    @field_validator("code", mode="before")
+    @classmethod
+    def validate_code(cls, value: str | None) -> str | None:
+        if value is None:
             return None
-        identifier = Identifier.from_query(query=self.source, system=DEVICE_SYSTEM)
-        logger.debug(f"Parsed source identifier: system={identifier.system}, value={identifier.value}")
-        if not identifier.system or not identifier.value:
-            return None
-        return identifier.value
-
-    def get_code_value(self) -> str | None:
-        logger.debug(f"Parsing code value from query: {self.code}")
-        if self.code is None:
-            return None
-        coding = Coding.from_query(query=self.code, system=DATA_DOMAIN_SYSTEM)
-        logger.debug(f"Parsed code value: system={coding.system}, code={coding.code}")
+        try:
+            coding = Coding.from_query(query=value, system=DATA_DOMAIN_SYSTEM)
+            logger.debug("Validated code: %r", coding)
+        except ValueError as e:
+            raise ValueError(f"Invalid code: {e}")
         if not coding.system or not coding.code:
             return None
         return coding.code
+
+    @field_validator("source", mode="before")
+    @classmethod
+    def validate_source(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        try:
+            identifier = Identifier.from_query(query=value, system=DEVICE_SYSTEM)
+            logger.debug("Validated source identifier: %r", identifier)
+        except ValueError as e:
+            raise ValueError(f"Invalid source identifier: {e}")
+        if not identifier.system or not identifier.value:
+            return None
+        return identifier.value
 
     def empty(self) -> bool:
         return self.subject is None and self.code is None and self.source is None

--- a/app/models/fhir/resources/localization_list/request.py
+++ b/app/models/fhir/resources/localization_list/request.py
@@ -1,9 +1,13 @@
+import logging
+
 from fastapi import Query
 from pydantic import BaseModel
 
-from app.models.fhir.elements import Identifier
+from app.models.fhir.elements import Coding, Identifier
 from app.models.fhir.resources.data import DATA_DOMAIN_SYSTEM, DEVICE_SYSTEM, PSEUDONYM_SYSTEM
 from app.routers.v1.fhir import CODE_PARAM, DEVICE_IDENTIFIER_PARAM, SUBJECT_IDENTIFIER_PARAM
+
+logger = logging.getLogger(__name__)
 
 
 class LocalizationListParams(BaseModel):
@@ -11,16 +15,36 @@ class LocalizationListParams(BaseModel):
     code: str | None = Query(alias=CODE_PARAM, example=f"{DATA_DOMAIN_SYSTEM}|code", default=None)
     source: str | None = Query(alias=DEVICE_IDENTIFIER_PARAM, example=f"{DEVICE_SYSTEM}|identifier", default=None)
 
-    def get_subject_identifier(self) -> Identifier:
+    def get_subject_identifier(self) -> str | None:
+        logger.debug(f"Parsing subject identifier from query: {self.subject}")
         if self.subject is None:
-            raise ValueError("Unable to retrieve required properties for Identifier object, subject value is None")
-        return Identifier.from_query(query=self.subject, system=PSEUDONYM_SYSTEM)
+            return None
+        identifier = Identifier.from_query(query=self.subject, system=PSEUDONYM_SYSTEM)
+        logger.debug(f"Parsed subject identifier: system={identifier.system}, value={identifier.value}")
+        if not identifier.system or not identifier.value:
+            # If system is left out e.g. "|12345" we don't return anything since our identifiers should always have a system: see https://r4.fhir.space/search.html#token
+            return None
+        return identifier.value
 
-    def get_source_identifier(self) -> Identifier:
+    def get_source_identifier(self) -> str | None:
+        logger.debug(f"Parsing source identifier from query: {self.source}")
         if self.source is None:
-            raise ValueError("Unable to retrieve required properties for Identifier object, source value is None")
+            return None
+        identifier = Identifier.from_query(query=self.source, system=DEVICE_SYSTEM)
+        logger.debug(f"Parsed source identifier: system={identifier.system}, value={identifier.value}")
+        if not identifier.system or not identifier.value:
+            return None
+        return identifier.value
 
-        return Identifier.from_query(query=self.source, system=DEVICE_SYSTEM)
+    def get_code_value(self) -> str | None:
+        logger.debug(f"Parsing code value from query: {self.code}")
+        if self.code is None:
+            return None
+        coding = Coding.from_query(query=self.code, system=DATA_DOMAIN_SYSTEM)
+        logger.debug(f"Parsed code value: system={coding.system}, code={coding.code}")
+        if not coding.system or not coding.code:
+            return None
+        return coding.code
 
     def empty(self) -> bool:
         return self.subject is None and self.code is None and self.source is None

--- a/app/models/fhir/resources/operation_outcome/resource.py
+++ b/app/models/fhir/resources/operation_outcome/resource.py
@@ -32,7 +32,6 @@ class OperationOutcome(DomainResource):
 
     @classmethod
     def make_good_outcome(cls, msg: str) -> Self:
-
         return cls(
             issue=[
                 OperationOutcomeIssue(

--- a/app/routers/v1/fhir/localization_list.py
+++ b/app/routers/v1/fhir/localization_list.py
@@ -229,7 +229,6 @@ def get(
     request: Request,
     service: Annotated[LocalizationListService, Depends(get_localization_list_service)],
 ) -> Any:
-
     authorized_ura: UraNumber = request.state.auth.ura_number
     return service.get(id, authorized_ura)
 
@@ -367,7 +366,6 @@ def delete_for_query(
     params: Annotated[LocalizationListParams, Query()],
     service: Annotated[LocalizationListService, Depends(get_localization_list_service)],
 ) -> Any:
-
     authenticated_ura = request.state.auth.ura_number
     outcome, status_code = service.delete_by_query(params, authenticated_ura)
 

--- a/app/services/fhir/localization_list.py
+++ b/app/services/fhir/localization_list.py
@@ -10,7 +10,7 @@ from app.models.fhir.resources.localization_list.resource import LocalizationLis
 from app.models.fhir.resources.operation_outcome.resource import OperationOutcome
 from app.models.pseudonym import Pseudonym
 from app.models.ura import UraNumber
-from app.routers.v1.fhir import CODE_PARAM, DEVICE_IDENTIFIER_PARAM, SUBJECT_IDENTIFIER_PARAM
+from app.routers.v1.fhir import SUBJECT_IDENTIFIER_PARAM
 from app.services.prs.pseudonym_service import PseudonymService
 from app.services.referral_service import ReferralService
 from app.utils.fhir import decode_url_safe_token
@@ -22,6 +22,22 @@ class LocalizationListService:
     def __init__(self, referral_service: ReferralService, pseudonym_service: PseudonymService) -> None:
         self.referral_service = referral_service
         self.pseudonym_service = pseudonym_service
+
+    def _token_to_pseudonym(self, token: str) -> Pseudonym:
+        try:
+            oprf_data = decode_url_safe_token(token)
+            return self.pseudonym_service.exchange(
+                oprf_jwe=oprf_data["evaluated_output"],
+                blind_factor=oprf_data["blind_factor"],
+            )
+        except Exception as e:
+            logger.error(f"error occurred while decoding pseudonym token: {e}")
+            raise FHIRException(
+                status_code=400,
+                severity="error",
+                code="invalid",
+                msg=f"Invalid pseudonym in {SUBJECT_IDENTIFIER_PARAM}",
+            )
 
     def create(self, data: LocalizationList, authenticated_ura: UraNumber) -> LocalizationList:
         try:
@@ -39,21 +55,7 @@ class LocalizationListService:
                 msg="Registration is not linked to the authorized URA",
             )
 
-        try:
-            encoded_token = data.get_encoded_pseudonym()
-            oprf_data = decode_url_safe_token(encoded_token)
-            pseudoym = self.pseudonym_service.exchange(
-                oprf_jwe=oprf_data["evaluated_output"],
-                blind_factor=oprf_data["blind_factor"],
-            )
-        except Exception as e:
-            logger.error(f"error occurred while decoding pseudonym token: {e}")
-            raise FHIRException(
-                status_code=400,
-                severity="error",
-                code="invalid",
-                msg=f"Invalid pseudonym in {SUBJECT_IDENTIFIER_PARAM}",
-            )
+        pseudoym = self._token_to_pseudonym(data.get_encoded_pseudonym())
 
         new_referral = self.referral_service.add_one(
             ura_number=ura_number,
@@ -76,74 +78,18 @@ class LocalizationListService:
 
         return LocalizationList.from_referral(referral)
 
-    def __parse_query_params(self, params: LocalizationListParams) -> Tuple[str | None, Pseudonym | None, str | None]:
-        code: str | None = None
-        pseudonym: Pseudonym | None = None
-        source: str | None = None
-
-        try:
-            subject_val = params.get_subject_identifier()
-        except ValueError as e:
-            logger.error(f"error occurred while parcing query: {e}")
-            raise FHIRException(
-                status_code=400,
-                severity="error",
-                code="invalid",
-                msg=f"Malformed {SUBJECT_IDENTIFIER_PARAM} parameter",
-            )
-
-        try:
-            source = params.get_source_identifier()
-        except ValueError as e:
-            logger.error(f"error occurred while parcing query: {e}")
-            raise FHIRException(
-                status_code=400,
-                severity="error",
-                code="invalid",
-                msg=f"Malformed {DEVICE_IDENTIFIER_PARAM} parameter",
-            )
-
-        try:
-            code = params.get_code_value()
-        except ValueError as e:
-            logger.error(f"error occurred while parsing code: {e}")
-            raise FHIRException(
-                status_code=400,
-                severity="error",
-                code="invalid",
-                msg=f"Malformed {CODE_PARAM} parameter",
-            )
-
-        if subject_val:
-            try:
-                oprf_data = decode_url_safe_token(subject_val)
-                pseudonym = self.pseudonym_service.exchange(
-                    oprf_jwe=oprf_data["evaluated_output"],
-                    blind_factor=oprf_data["blind_factor"],
-                )
-            except Exception as e:
-                logger.error(f"error occurred while decoding pseudonym token: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg=f"Invalid pseudonym in {SUBJECT_IDENTIFIER_PARAM}",
-                )
-        logger.debug(f"Parsed query parameters: code={code}, pseudonym={pseudonym}, source={source}")
-        return code, pseudonym, source
-
     def query(self, params: LocalizationListParams, authenticated_ura: UraNumber) -> Bundle[LocalizationList]:
         ura_number: UraNumber | None = None
 
         if params.empty() or params.is_localize_params() is False:
             ura_number = authenticated_ura
 
-        code, pseudonym, source = self.__parse_query_params(params)
+        pseudonym = self._token_to_pseudonym(params.subject) if params.subject else None
 
         referrals = self.referral_service.get_many(
             pseudonym=pseudonym,
-            source=source,
-            data_domain=DataDomain(code) if code else None,
+            source=params.source,
+            data_domain=DataDomain(params.code) if params.code else None,
             ura_number=ura_number,
         )
         bundle = Bundle(
@@ -172,12 +118,12 @@ class LocalizationListService:
     ) -> Tuple[OperationOutcome, int]:
         ura_number = authenticated_ura
 
-        code, pseudonym, source = self.__parse_query_params(params)
+        pseudonym = self._token_to_pseudonym(params.subject) if params.subject else None
 
         self.referral_service.delete_many(
             pseudonym=pseudonym,
-            source=source,
-            data_domain=DataDomain(code) if code else None,
+            source=params.source,
+            data_domain=DataDomain(params.code) if params.code else None,
             ura_number=ura_number,
         )
 

--- a/app/services/fhir/localization_list.py
+++ b/app/services/fhir/localization_list.py
@@ -1,5 +1,3 @@
-import base64
-import json
 import logging
 from typing import Tuple
 from uuid import UUID
@@ -12,7 +10,7 @@ from app.models.fhir.resources.localization_list.resource import LocalizationLis
 from app.models.fhir.resources.operation_outcome.resource import OperationOutcome
 from app.models.pseudonym import Pseudonym
 from app.models.ura import UraNumber
-from app.routers.v1.fhir import SUBJECT_IDENTIFIER_PARAM
+from app.routers.v1.fhir import CODE_PARAM, DEVICE_IDENTIFIER_PARAM, SUBJECT_IDENTIFIER_PARAM
 from app.services.prs.pseudonym_service import PseudonymService
 from app.services.referral_service import ReferralService
 from app.utils.fhir import decode_url_safe_token
@@ -78,29 +76,47 @@ class LocalizationListService:
 
         return LocalizationList.from_referral(referral)
 
-    def query(self, params: LocalizationListParams, authenticated_ura: UraNumber) -> Bundle[LocalizationList]:
+    def __parse_query_params(self, params: LocalizationListParams) -> Tuple[str | None, Pseudonym | None, str | None]:
         code: str | None = None
         pseudonym: Pseudonym | None = None
         source: str | None = None
-        ura_number: UraNumber | None = None
 
-        if params.empty() or params.is_localize_params() is False:
-            ura_number = authenticated_ura
+        try:
+            subject_val = params.get_subject_identifier()
+        except ValueError as e:
+            logger.error(f"error occurred while parcing query: {e}")
+            raise FHIRException(
+                status_code=400,
+                severity="error",
+                code="invalid",
+                msg=f"Malformed {SUBJECT_IDENTIFIER_PARAM} parameter",
+            )
 
-        if params.subject:
+        try:
+            source = params.get_source_identifier()
+        except ValueError as e:
+            logger.error(f"error occurred while parcing query: {e}")
+            raise FHIRException(
+                status_code=400,
+                severity="error",
+                code="invalid",
+                msg=f"Malformed {DEVICE_IDENTIFIER_PARAM} parameter",
+            )
+
+        try:
+            code = params.get_code_value()
+        except ValueError as e:
+            logger.error(f"error occurred while parsing code: {e}")
+            raise FHIRException(
+                status_code=400,
+                severity="error",
+                code="invalid",
+                msg=f"Malformed {CODE_PARAM} parameter",
+            )
+
+        if subject_val:
             try:
-                subject_identifier = params.get_subject_identifier()
-            except ValueError as e:
-                logger.error(f"error occurred while parcing query: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg=f"Malformed {SUBJECT_IDENTIFIER_PARAM} parameter",
-                )
-
-            try:
-                oprf_data = decode_url_safe_token(subject_identifier.value)
+                oprf_data = decode_url_safe_token(subject_val)
                 pseudonym = self.pseudonym_service.exchange(
                     oprf_jwe=oprf_data["evaluated_output"],
                     blind_factor=oprf_data["blind_factor"],
@@ -113,28 +129,22 @@ class LocalizationListService:
                     code="invalid",
                     msg=f"Invalid pseudonym in {SUBJECT_IDENTIFIER_PARAM}",
                 )
+        logger.debug(f"Parsed query parameters: code={code}, pseudonym={pseudonym}, source={source}")
+        return code, pseudonym, source
 
-        if params.source:
-            try:
-                source_identifier = params.get_source_identifier()
-                source = source_identifier.value
-            except ValueError as e:
-                logger.error(f"error occurred while parcing query: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg="Malformed source.identifier parameter",
-                )
+    def query(self, params: LocalizationListParams, authenticated_ura: UraNumber) -> Bundle[LocalizationList]:
+        ura_number: UraNumber | None = None
 
-        if params.code:
-            code = params.code
+        if params.empty() or params.is_localize_params() is False:
+            ura_number = authenticated_ura
+
+        code, pseudonym, source = self.__parse_query_params(params)
 
         referrals = self.referral_service.get_many(
             pseudonym=pseudonym,
             source=source,
             data_domain=DataDomain(code) if code else None,
-            ura_number=ura_number if ura_number else None,
+            ura_number=ura_number,
         )
         bundle = Bundle(
             type="searchset",
@@ -148,7 +158,7 @@ class LocalizationListService:
         affected_rows = self.referral_service.delete_many(ura_number=authenticated_ura, id=id)
         if affected_rows > 0:
             return (
-                OperationOutcome.make_good_outcome(f"Resource {id} have been deleted successfully"),
+                OperationOutcome.make_good_outcome(f"Resource {id} has been deleted successfully"),
                 201,
             )
         else:
@@ -160,54 +170,9 @@ class LocalizationListService:
     def delete_by_query(
         self, params: LocalizationListParams, authenticated_ura: UraNumber
     ) -> Tuple[OperationOutcome, int]:
-        code: str | None = None
-        pseudonym: Pseudonym | None = None
-        source: str | None = None
         ura_number = authenticated_ura
 
-        if params.subject:
-            try:
-                subject_identifier = params.get_subject_identifier()
-            except ValueError as e:
-                logger.error(f"error occurred while parcing query: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg=f"Malformed {SUBJECT_IDENTIFIER_PARAM} parameter",
-                )
-
-            try:
-                decoded_token = base64.urlsafe_b64decode(subject_identifier.value)
-                oprf_data = json.loads(decoded_token)
-                pseudonym = self.pseudonym_service.exchange(
-                    oprf_jwe=oprf_data["evaluated_output"],
-                    blind_factor=oprf_data["blind_factor"],
-                )
-            except Exception as e:
-                logger.error(f"error occurred while decoding pseudonym token: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg=f"Invalid pseudonym in {SUBJECT_IDENTIFIER_PARAM}",
-                )
-
-        if params.source:
-            try:
-                source_identifier = params.get_source_identifier()
-                source = source_identifier.value
-            except ValueError as e:
-                logger.error(f"error occurred while parcing query: {e}")
-                raise FHIRException(
-                    status_code=400,
-                    severity="error",
-                    code="invalid",
-                    msg="Malformed source.identifier parameter",
-                )
-
-        if params.code:
-            code = params.code
+        code, pseudonym, source = self.__parse_query_params(params)
 
         self.referral_service.delete_many(
             pseudonym=pseudonym,
@@ -217,6 +182,6 @@ class LocalizationListService:
         )
 
         return (
-            OperationOutcome.make_good_outcome("Resources have beend deleted successfully"),
+            OperationOutcome.make_good_outcome("Resources have been deleted successfully"),
             201,
         )

--- a/tests/models/fhir/test_elements.py
+++ b/tests/models/fhir/test_elements.py
@@ -1,3 +1,5 @@
+import pytest
+
 from app.models.fhir.elements import CodeableConcept, Coding, Identifier
 
 
@@ -53,3 +55,63 @@ def test_deserialize_identifier_should_succeed() -> None:
     actual = Identifier.model_validate(data)
 
     assert expected == actual
+
+
+def test_coding_from_query_bare_code_uses_default_system() -> None:
+    actual = Coding.from_query("some-code", system="some-system")
+    assert actual == Coding(system="some-system", code="some-code")
+
+
+def test_coding_from_query_system_and_code() -> None:
+    actual = Coding.from_query("some-system|some-code", system="some-system")
+    assert actual == Coding(system="some-system", code="some-code")
+
+
+def test_coding_from_query_absent_system() -> None:
+    actual = Coding.from_query("|some-code", system="some-system")
+    assert actual == Coding(system="", code="some-code")
+
+
+def test_coding_from_query_system_only_any_code() -> None:
+    actual = Coding.from_query("some-system|", system="some-system")
+    assert actual == Coding(system="some-system", code="")
+
+
+def test_coding_from_query_unknown_system_raises() -> None:
+    with pytest.raises(ValueError, match="Unrecognized system"):
+        Coding.from_query("other-system|some-code", system="some-system")
+
+
+def test_coding_from_query_multiple_pipes_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid query format"):
+        Coding.from_query("a|b|c", system="some-system")
+
+
+def test_identifier_from_query_bare_value_uses_default_system() -> None:
+    actual = Identifier.from_query("some-value", system="some-system")
+    assert actual == Identifier(system="some-system", value="some-value")
+
+
+def test_identifier_from_query_system_and_value() -> None:
+    actual = Identifier.from_query("some-system|some-value", system="some-system")
+    assert actual == Identifier(system="some-system", value="some-value")
+
+
+def test_identifier_from_query_absent_system() -> None:
+    actual = Identifier.from_query("|some-value", system="some-system")
+    assert actual == Identifier(system="", value="some-value")
+
+
+def test_identifier_from_query_system_only_any_value() -> None:
+    actual = Identifier.from_query("some-system|", system="some-system")
+    assert actual == Identifier(system="some-system", value="")
+
+
+def test_identifier_from_query_unknown_system_raises() -> None:
+    with pytest.raises(ValueError, match="Unrecognized system"):
+        Identifier.from_query("other-system|some-value", system="some-system")
+
+
+def test_identifier_from_query_multiple_pipes_raises() -> None:
+    with pytest.raises(ValueError, match="Invalid query format"):
+        Identifier.from_query("a|b|c", system="some-system")

--- a/tests/services/test_referral_service.py
+++ b/tests/services/test_referral_service.py
@@ -21,7 +21,6 @@ def assert_eq(
     """
 
     def compare(expected: ReferralEntity, actual: ReferralEntity) -> None:
-
         expected_attr = expected.__table__.columns.keys()
         actual_attr = actual.__table__.columns.keys()
 


### PR DESCRIPTION
This pull request introduces subsumption-based logic for the v1 query and delete with params endpoints and modifies the handling of parameters. It also includes some extra debug logging.

Should fix: https://github.com/minvws/gfmodules-nationale-verwijsindex/issues/416 and https://github.com/minvws/gfmodules-nationale-verwijsindex/issues/417

See https://r4.fhir.space/search.html#token for info on the subsumption logic.

```
[parameter]=[code]: the value of [code] matches a Coding.code or Identifier.value irrespective of the value of the system property
[parameter]=[system]|[code]: the value of [code] matches a Coding.code or Identifier.value, and the value of [system] matches the system property of the Identifier or Coding
[parameter]=|[code]: the value of [code] matches a Coding.code or Identifier.value, and the Coding/Identifier has no system property
[parameter]=[system]|: any element where the value of [system] matches the system property of the Identifier or Coding
```