### PR TITLE
fix: migrations onn data_domain

### DIFF
--- a/sql/020-alter-data-domain-column.sql
+++ b/sql/020-alter-data-domain-column.sql
@@ -1,0 +1,3 @@
+ALTER TABLE referrals DROP CONSTRAINT providers_unique_idx;
+ALTER TABLE referrals ADD CONSTRAINT providers_unique_idx UNIQUE (ura_number, pseudonym, source);
+ALTER TABLE referrals ALTER COLUMN data_domain DROP NOT NULL;

--- a/sql/020-remove-data-domain-column.sql
+++ b/sql/020-remove-data-domain-column.sql
@@ -1,3 +1,0 @@
-ALTER TABLE referrals DROP CONSTRAINT providers_unique_idx;
-ALTER TABLE referrals DROP COLUMN data_domain;
-ALTER TABLE referrals ADD CONSTRAINT providers_unique_idx UNIQUE (ura_number, pseudonym, source);


### PR DESCRIPTION
The current modified migrations are not deployed yet. Therefor it is safe to modify them accordingly.

This PR reverts the drop of `data_domain` column for backwards compatibility with v0.1 until the former is deprecated. 