### PR TITLE
Ignore FastAPI cve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ type-check: ## Check for typing errors
 	$(RUN_PREFIX) mypy app tests
 
 safety-check: ## Check for security vulnerabilities
-	$(RUN_PREFIX) pip-audit
+	$(RUN_PREFIX) pip-audit --ignore-vuln="MAL-2026-4750"
 
 spelling-check: ## Check spelling mistakes
 	$(RUN_PREFIX) codespell . --skip="./app/data.py" --skip="./publiccode.yml"


### PR DESCRIPTION
Related to https://github.com/fastapi/fastapi/issues/15612

So we can build a docker image on version tag for now.