### PR TITLE
Add trivyignore.rego file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -213,6 +213,7 @@ jobs:
           exit-code: "0"
           severity: "CRITICAL,HIGH"
           vuln-type: "library"
+          ignore-policy: .trivyignore.rego
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v4
@@ -229,6 +230,7 @@ jobs:
           exit-code: ${{ (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')) && '0' || '1' }}
           severity: "CRITICAL,HIGH"
           vuln-type: "library"
+          ignore-policy: .trivyignore.rego
           skip-setup-trivy: true
 
       - name: Push Docker image

--- a/.trivyignore.rego
+++ b/.trivyignore.rego
@@ -1,0 +1,18 @@
+package trivy
+
+default ignore = false
+
+ignore {
+    input.VulnerabilityID == "CVE-2026-59890"
+    input.PkgIdentifier.BOMRef == "pkg:pypi/setuptools@70.3.0"
+}
+
+ignore {
+    input.VulnerabilityID == "CVE-2025-47273"
+    input.PkgIdentifier.BOMRef == "pkg:pypi/setuptools@70.3.0"
+}
+
+ignore {
+    input.VulnerabilityID == "GHSA-6v7p-g79w-8964"
+    input.PkgIdentifier.BOMRef == "pkg:pypi/msgpack@1.1.2"
+}


### PR DESCRIPTION
To exclude the sbom found vulnerabilities of pip.

Related to https://github.com/aquasecurity/trivy/discussions/11031 and https://github.com/minvws/gfmodules-coordination-private/issues/1076
